### PR TITLE
Update "ADOPT" instructions for ESP-MBUS

### DIFF
--- a/ESP-MBUS/README.md
+++ b/ESP-MBUS/README.md
@@ -28,8 +28,8 @@ Compiled binary: https://github.com/ficueu/ESPHome-IoT-modules/blob/main/ESP-MBU
 
 3. Open the web browser and go to 192.168.4.1 and fill your SSID and password, click on save.
 
-4. Your device should be visible on ESPHome addon with name and green button "ADOPT" - click on this button, install device and flash it.
-If the device can not be adopted please create a new device (name and device type doesn't matter, you can choose esp32 with recommended settings), next edit the device and replace config with Example ESPHome yaml file, next upload configuration via usb cable.
+4. Your device should be visible on ESPHome addon with name and green button "TAKE CONTROL" - click on this button, install device and flash it.
+If the device can not be taken control of, please create a new device (name and device type doesn't matter, you can choose esp32 with recommended settings), next edit the device and replace config with Example ESPHome yaml file, next upload configuration via usb cable.
 
 5. This device is based on SzczepanLeon wmbus component, you can find example configuration here: https://github.com/SzczepanLeon/esphome-components
 


### PR DESCRIPTION
The current version of ESPHome seems to use "TAKE CONTROL OF" instead:

<img width="527" alt="image" src="https://github.com/user-attachments/assets/8ddd9b3b-ac39-4c75-beb4-264f81abd503" />
